### PR TITLE
Noghost

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,4 +8,4 @@ Description: Create a lightweight Shiny wrapper for the css-loaders created by L
 License: GPL-3
 URL: https://github.com/andrewsali/shinycssloaders
 Imports: digest, glue, grDevices, shiny
-RoxygenNote: 5.0.1
+RoxygenNote: 6.0.1

--- a/R/withSpinner.R
+++ b/R/withSpinner.R
@@ -126,7 +126,7 @@ withSpinner <- function(ui_element,type=getOption("spinner.type",default=1),colo
     css_color,
     css_size,
     shiny::div(class="shiny-spinner-output-container",
-               shiny::div(class=sprintf("load-container load%s",type),
+               shiny::div(class=sprintf("load-container load%s shiny-spinner-hidden",type),
                           shiny::div(id=id,class="loader","Loading...")
                ),
                proxy_element,

--- a/inst/assets/spinner.js
+++ b/inst/assets/spinner.js
@@ -1,15 +1,48 @@
-/* When recalculating starts, show the spinner container & hide the output */
-$(document).on('shiny:recalculating', function(event) {
-    $(".recalculating").siblings(".load-container, .shiny-spinner-placeholder").removeClass('shiny-spinner-hidden');
-    $(".recalculating").siblings(".load-container").siblings('.shiny-bound-output, .shiny-output-error').css('visibility', 'hidden');
+(function() {
+var output_states = [];
+
+function show_spinner(id) {
+    $("#"+id).siblings(".load-container, .shiny-spinner-placeholder").removeClass('shiny-spinner-hidden');
+    $("#"+id).siblings(".load-container").siblings('.shiny-bound-output, .shiny-output-error').css('visibility', 'hidden');
     // if there is a proxy div, hide the previous output
-    $(".recalculating").siblings(".shiny-spinner-placeholder").siblings('.shiny-bound-output, .shiny-output-error').addClass('shiny-spinner-hidden');
+    $("#"+id).siblings(".shiny-spinner-placeholder").siblings('.shiny-bound-output, .shiny-output-error').addClass('shiny-spinner-hidden');
+}
+
+function hide_spinner(id) {
+    $("#"+id).siblings(".load-container, .shiny-spinner-placeholder").addClass('shiny-spinner-hidden');
+    $("#"+id).siblings(".load-container").siblings('.shiny-bound-output').css('visibility', 'visible');
+    // if there is a proxy div, show the previous output in case it was hidden
+    $("#"+id).siblings(".shiny-spinner-placeholder").siblings('.shiny-bound-output').removeClass('shiny-spinner-hidden');
+}
+
+function update_spinner(id) {
+  if (!(id in output_states)) {
+    show_spinner(id);
+  }
+  if (output_states[id] <= 0) {
+    show_spinner(id);
+  } else {
+    hide_spinner(id);
+  }
+}
+
+$(document).on('shiny:bound', function(event){ 
+  /* if not bound before, then set the value to 0 */
+  if (!(event.target.id in output_states)) {
+    output_states[event.target.id] = 0;
+  }
+  update_spinner(event.target.id);
+});
+
+/* When recalculating starts, show the spinner container & hide the output */
+$(document).on('shiny:outputinvalidated', function(event) {
+  output_states[event.target.id] = 0;
+  update_spinner(event.target.id);
 });
 
 /* When new value or error comes in, hide spinner container (if any) & show the output */
 $(document).on('shiny:value shiny:error', function(event) {
-    $("#"+event.target.id).siblings(".load-container, .shiny-spinner-placeholder").addClass('shiny-spinner-hidden');
-    $("#"+event.target.id).siblings(".load-container").siblings('.shiny-bound-output').css('visibility', 'visible');
-    // if there is a proxy div, show the previous output in case it was hidden
-    $("#"+event.target.id).siblings(".shiny-spinner-placeholder").siblings('.shiny-bound-output').removeClass('shiny-spinner-hidden');
+  output_states[event.target.id] = 1;
+  update_spinner(event.target.id);
 });
+}());

--- a/man/shinycssloaders.Rd
+++ b/man/shinycssloaders.Rd
@@ -14,4 +14,3 @@ also customize the color / size of the animation.
 \details{
 For further reference on how to use the package, please refer to \url{https://github.com/andrewsali/shinycssloaders}
 }
-

--- a/man/withSpinner.Rd
+++ b/man/withSpinner.Rd
@@ -32,4 +32,3 @@ Add a spinner (loader) that shows when an output is recalculating
 \examples{
 \dontrun{withSpinner(plotOutput("my_plot"))}
 }
-


### PR DESCRIPTION
This PR introduces internal housekeeping of the shiny output load-state. This is designed to ensure that when dynamic outputs are possibly recreated and thus `shiny:value` or `shiny:error` events are fired before the spinner element enters the DOM, then no ghosting (i.e. infinitely lived spinner) occurs.