### PR TITLE
Escape special IDs

### DIFF
--- a/inst/assets/spinner.js
+++ b/inst/assets/spinner.js
@@ -1,18 +1,24 @@
 (function() {
 var output_states = [];
 
+function escapeSelector(s) {
+    return s.replace(/([!"#$%&'()*+,-./:;<=>?@\[\\\]^`{|}~])/g, "\\$1");
+}
+
 function show_spinner(id) {
-    $("#"+id).siblings(".load-container, .shiny-spinner-placeholder").removeClass('shiny-spinner-hidden');
-    $("#"+id).siblings(".load-container").siblings('.shiny-bound-output, .shiny-output-error').css('visibility', 'hidden');
+    var selector = "#"+escapeSelector(id);
+    $(selector).siblings(".load-container, .shiny-spinner-placeholder").removeClass('shiny-spinner-hidden');
+    $(selector).siblings(".load-container").siblings('.shiny-bound-output, .shiny-output-error').css('visibility', 'hidden');
     // if there is a proxy div, hide the previous output
-    $("#"+id).siblings(".shiny-spinner-placeholder").siblings('.shiny-bound-output, .shiny-output-error').addClass('shiny-spinner-hidden');
+    $(selector).siblings(".shiny-spinner-placeholder").siblings('.shiny-bound-output, .shiny-output-error').addClass('shiny-spinner-hidden');
 }
 
 function hide_spinner(id) {
-    $("#"+id).siblings(".load-container, .shiny-spinner-placeholder").addClass('shiny-spinner-hidden');
-    $("#"+id).siblings(".load-container").siblings('.shiny-bound-output').css('visibility', 'visible');
+    var selector = "#"+escapeSelector(id);
+    $(selector).siblings(".load-container, .shiny-spinner-placeholder").addClass('shiny-spinner-hidden');
+    $(selector).siblings(".load-container").siblings('.shiny-bound-output').css('visibility', 'visible');
     // if there is a proxy div, show the previous output in case it was hidden
-    $("#"+id).siblings(".shiny-spinner-placeholder").siblings('.shiny-bound-output').removeClass('shiny-spinner-hidden');
+    $(selector).siblings(".shiny-spinner-placeholder").siblings('.shiny-bound-output').removeClass('shiny-spinner-hidden');
 }
 
 function update_spinner(id) {


### PR DESCRIPTION
Escaping the input ids for jQuery selector.   Resolves issue #16.  

Shiny's bookmarking feature creates an input with an id of "._bookmark_".  This input id was throwing the following javascript error when used as a jQuery selector

```
Uncaught Error: Syntax error, unrecognized expression: #._bookmark_
    at Function.fa.error (jquery.min.js:2)
    at fa.tokenize (jquery.min.js:2)
    at fa.select (jquery.min.js:2)
    at Function.fa [as find] (jquery.min.js:2)
    at n.fn.init.find (jquery.min.js:2)
    at new n.fn.init (jquery.min.js:2)
    at n (jquery.min.js:2)
    at show_spinner (spinner.js:5)
    at update_spinner (spinner.js:23)
    at HTMLDocument.<anonymous> (spinner.js:34)
```

The error was resolved by @andrewsali commit ab4cff1542bed6f996c0783a2911eeae7f80530e which escapes jQuery selector special characters.  Specifically the "." for the case of the bookmarking issue mentioned above.

Additional detail on the regex used to escape the jQuery selector can be found here: https://stackoverflow.com/questions/2786538/need-to-escape-a-special-character-in-a-jquery-selector-string